### PR TITLE
iterator parameter - fixed

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -106,6 +106,7 @@ class AddressBook(UserDict):
 
     def iterator(self, n=2) -> GeneratorType:
         ''' generator '''
+        n = int(n)
         for i in range(0, len(self), n):
             yield islice(self.data.values(), i, i+n)
 


### PR DESCRIPTION
Було:
>>>all 5
Traceback
TypeError: 'str' object cannot be interpreted as an integer

Стало:
>>>all 5
видає 5 контактів за ітерацію